### PR TITLE
Add secret for admin user

### DIFF
--- a/mlx/base/kustomization.yaml
+++ b/mlx/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - api-service.yaml
   - api-serviceaccount.yaml
   - ui-serviceaccount.yaml
+  - ui-secret.yaml
   - ui-deployment.yaml
   - ui-service.yaml
   - ui-virtualservice.yaml

--- a/mlx/base/ui-deployment.yaml
+++ b/mlx/base/ui-deployment.yaml
@@ -31,5 +31,21 @@ spec:
           value: "true"
         - name: REACT_APP_BASE_PATH
           value: /os
+        - name: SESSION_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: dashboard-admin
+              key: sesstion
         ports:
         - containerPort: 3000
+        volumeMounts:
+        - mountPath: /workspace/models
+          name: dashboard-admin
+          readOnly: true
+      volumes:
+      - name: dashboard-admin
+        secret:
+          items:
+          - key: admin.json
+            path: admin.json
+          secretName: dashboard-admin

--- a/mlx/base/ui-secret.yaml
+++ b/mlx/base/ui-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dashboard-admin
+type: Opaque
+stringData:
+  admin.json: |
+    {
+      "admin": { "password": "passw0rd", "roles": ["admin"] }
+    }
+  sesstion: "machine learning exchange"


### PR DESCRIPTION
Store user, password and roles in the secret object and
mount to mlx-ui pod as a JSON file.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>
